### PR TITLE
User `prepend_before` instead of `prepend` for RSpec

### DIFF
--- a/lib/karafka/testing/rspec/helpers.rb
+++ b/lib/karafka/testing/rspec/helpers.rb
@@ -29,7 +29,7 @@ module Karafka
             # Producer fake client to mock communication with Kafka
             base.let(:_karafka_producer_client) { Karafka::Testing::SpecProducerClient.new(self) }
 
-            base.before do
+            base.prepend_before do
               _karafka_consumer_messages.clear
               _karafka_producer_client.reset
 


### PR DESCRIPTION
If there are `before` hooks defined before the karafka helper (or global `config.before` hooks) that send kafka events, they would be performed before `Karafka.producer.client` is mocked and real kafka will be used.
Prepend karafka mocks, so they're executed first (unless another `prepend_before` is used afterwards).

Note, there is still an issue with sending kafka events from `around` hooks: `before` hooks are executed inside `example.run`, so part of `around` hook before that would run without mocked karafka. There is no `prepend_around` to fix it.