### PR TITLE
Fix instance variable in minitest helper

### DIFF
--- a/lib/karafka/testing/minitest/helpers.rb
+++ b/lib/karafka/testing/minitest/helpers.rb
@@ -163,7 +163,7 @@ module Karafka
           # Inject appropriate strategy so needed options and components are available
           strategy = Karafka::App.config.internal.processing.strategy_selector.find(topic)
           @consumer.singleton_class.include(strategy)
-          @consumer.client = @karafka_consumer_client
+          @consumer.client = @_karafka_consumer_client
           @consumer.coordinator = coordinators.find_or_create(topic.name, 0)
           @consumer.coordinator.seek_offset = 0
           # Indicate usage as for tests no direct enqueuing happens


### PR DESCRIPTION
### Environment
- Ruby: 3.0.6
- karafka: 2.3.4
- karafka-testing: 2.3.3

### Observed Behavior
Using methods such as mark_as_consumed causes the tests to fail due to unhandled method calls.

```ruby
# events_consumer.rb
class EventsConsumer < ApplicationConsumer
  def consume
    messages.each do |message|
      mark_as_consumed(message)
    end
  end
end

# events_consumer_test.rb
require "test_helper"

class EventsConsumerTest < ActiveSupport::TestCase
  include Karafka::Testing::Minitest::Helpers

  def setup
    @consumer = @karafka.consumer_for("events")
  end

  test "consume" do
    Karafka.producer.produce_async(topic: "events", payload: { foo: "bar" }.to_json, key: "key")

    @consumer.consume
  end
end
```

When running the test, the following error occurs:
```
Minitest::UnexpectedError: NoMethodError: undefined method `assignment_lost?' for nil:NilClass
```

### Fix
Modify `@consumer.client` to instantiate `Karafka::Testing::SpecConsumerClient`. This change ensures that the `assignment_lost?` method can return a correctly mocked value