### PR TITLE
Fix FrozenError when accessing key and headers in Karafka::Messages::Metadata

### DIFF
--- a/lib/karafka/testing/minitest/helpers.rb
+++ b/lib/karafka/testing/minitest/helpers.rb
@@ -100,7 +100,7 @@ module Karafka
           # Add this message to previously produced messages
           @_karafka_consumer_messages << Karafka::Messages::Message.new(
             message[:payload],
-            Karafka::Messages::Metadata.new(metadata).freeze
+            Karafka::Messages::Metadata.new(metadata)
           )
           # Update batch metadata
           batch_metadata = Karafka::Messages::Builders::BatchMetadata.call(

--- a/lib/karafka/testing/rspec/helpers.rb
+++ b/lib/karafka/testing/rspec/helpers.rb
@@ -108,7 +108,7 @@ module Karafka
           # Add this message to previously produced messages
           _karafka_consumer_messages << Karafka::Messages::Message.new(
             message[:payload],
-            Karafka::Messages::Metadata.new(metadata).freeze
+            Karafka::Messages::Metadata.new(metadata)
           )
 
           # Update batch metadata


### PR DESCRIPTION
### Environment
- Ruby: 3.0.6
- karafka: 2.4.0
- karafka-testing: 2.4.1

### Observed Behavior
Accessing methods `key` and `headers` in `Karafka::Messages::Metadata` causes the tests to fail due to `FrozenError`.

```ruby
# events_consumer.rb
class EventsConsumer < ApplicationConsumer
  def consume
    messages.each do |message|
      puts message.key, message.headers
    end
  end
end

# events_consumer_test.rb
require "test_helper"

class EventsConsumerTest < ActiveSupport::TestCase
  include Karafka::Testing::Minitest::Helpers

  def setup
    @consumer = @karafka.consumer_for("events")
  end

  test "consume" do
    Karafka.producer.produce_async(topic: "events", payload: { foo: "bar" }.to_json, key: "key")

    @consumer.consume
  end
end
```

When running the test, the following error occurs:
```
Minitest::UnexpectedError: FrozenError: can't modify frozen Karafka::Messages::Metadata
```

### Fix
As required by karafka/karafka#2007, Karafka::Messages::Metadata should not be frozen. I have modified the RSpec and Minitest helpers to unfreeze Metadata.