### PR TITLE
Fix: raw_key is not being assigned

### DIFF
--- a/lib/karafka/testing/rspec/helpers.rb
+++ b/lib/karafka/testing/rspec/helpers.rb
@@ -99,10 +99,13 @@ module Karafka
           # Build message metadata and copy any metadata that would come from the message
           metadata = _karafka_message_metadata_defaults
 
+          mapping = { raw_key: :key }
           metadata.keys.each do |key|
-            next unless message.key?(key)
+            message_key = mapping.fetch(key, key)
 
-            metadata[key] = message.fetch(key)
+            next unless message.key?(message_key)
+
+            metadata[key] = message.fetch(message_key)
           end
 
           # Add this message to previously produced messages


### PR DESCRIPTION
## Environment
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-darwin23]
karafka (2.4.0)
karafka-testing (2.4.2)

## Current Behavior
When it is a tombstone message, the code tries to get the `key` but it always returns `nil` because there is no mapping between `raw_key` and `key`. Karafka gem has a deserializer that looks for `raw_key` (https://github.com/karafka/karafka/blob/master/lib/karafka/deserializers/key.rb#L11)
```ruby
# ...
  def consume
    messages.each do |message|
      ...
        consume_tombstone_message(key: message.key)
      ...
    end
  end
# ...
```

## Fix
Copy the value from message `key` to metadata `raw_key`