### PR TITLE
stub with dummy pre before in rspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Testing Changelog
 
 ## 2.5.2 (Unreleased)
+- [Enhancement] Change RSpec hook execution order issue in Karafka testing helpers.
 - [Change] Remove `funding_uri` from the gemspec to minimize double-funding info.
 - [Change] Add new CI action to trigger auto-doc refresh.
 

--- a/lib/karafka/testing/rspec/helpers.rb
+++ b/lib/karafka/testing/rspec/helpers.rb
@@ -39,9 +39,14 @@ module Karafka
             # Producer fake client to mock communication with Kafka
             base.let(:_karafka_producer_client) { Karafka::Testing::SpecProducerClient.new(self) }
 
-            base.prepend_before do
+            base.before(:context) do
               Karafka::Testing.ensure_karafka_initialized!
+              @_karafka_shared_producer_client = WaterDrop::Clients::Dummy.new(-1)
+              Karafka.producer.instance_variable_set(:'@client', @_karafka_shared_producer_client)
+              Karafka.producer.instance_variable_set(:'@pid', ::Process.pid)
+            end
 
+            base.prepend_before do
               _karafka_consumer_messages.clear
               _karafka_producer_client.reset
               @_karafka_consumer_mappings = {}


### PR DESCRIPTION
close https://github.com/karafka/karafka-testing/issues/268

since users may have `around` and other flows where producer is invoked earlier, this code uses a dummy as early in the context as possible. That way eventual dispatches of data can be ignored. This will ignore them as the context stuff anyhow should not be shared but will at the same time prevent this from leaking to kafka (which we want to avoid with this lib).
