### PR TITLE
Lower setup-ruby age gate to 5 days and schedule lock file maintenanc…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,12 +24,22 @@
       ],
       "groupName": "ruby setup",
       "internalChecksFilter": "strict"
+    },
+    {
+      "description": "Let setup-ruby pass age gate before ruby so it is ready when the group PR is created",
+      "matchPackageNames": [
+        "ruby/setup-ruby"
+      ],
+      "minimumReleaseAge": "5 days"
     }
   ],
   "labels": [
     "dependencies"
   ],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "before 4am on the first day of the month"
+    ]
   }
 }


### PR DESCRIPTION
…e monthly

- Add a 5-day minimumReleaseAge for setup-ruby so its update clears the age gate before ruby's 7-day gate opens, ensuring both land in the same grouped PR.
- Schedule lock file maintenance to run monthly instead of weekly, so transitive dependency updates respect the 7-day age gate in practice.