### PR TITLE
Fix SimpleCov add_filter deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.6.2)
-    docile (1.4.1)
     drb (2.2.3)
     ffi (1.17.4)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -58,12 +57,7 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
     ruby2_keywords (0.0.5)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.0)
     warning (1.6.0)
     waterdrop (2.10.2)
       karafka-core (>= 2.5.12, < 3.0.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,15 +23,15 @@ if coverage
   require "simplecov"
 
   SimpleCov.start do
-    add_filter "/test/"
-    add_filter "/vendor/"
-    add_filter "/gems/"
-    add_filter "/.bundle/"
-    add_filter "/doc/"
-    add_filter "/config/"
+    skip "/test/"
+    skip "/vendor/"
+    skip "/gems/"
+    skip "/.bundle/"
+    skip "/doc/"
+    skip "/config/"
     # Helpers require full Karafka integration to test properly
-    add_filter "/lib/karafka/testing/rspec/helpers.rb"
-    add_filter "/lib/karafka/testing/minitest/helpers.rb"
+    skip "/lib/karafka/testing/rspec/helpers.rb"
+    skip "/lib/karafka/testing/minitest/helpers.rb"
 
     merge_timeout 600
     minimum_coverage 100


### PR DESCRIPTION
SimpleCov 1.0.0 renamed `add_filter` to `skip` (same arguments and behavior) and the old name now emits a deprecation warning. Our test helper promotes warnings to errors, so the suite would break as soon as SimpleCov resolved to 1.0.0.

Rename the eight `add_filter` calls in test/test_helper.rb to `skip` and bump the locked simplecov to 1.0.0, since `skip` only exists there. simplecov 1.0.0 has no runtime dependencies, so docile, simplecov-html and simplecov_json_formatter drop out of the lockfile.