### PR TITLE
Standardize yard-lint config: enable em-dash substitution as error

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -82,6 +82,14 @@ Documentation/LineLength:
   # Aligned with RuboCop's Layout/LineLength (Max: 100).
   MaxLength: 100
 
+Documentation/TextSubstitution:
+  Description: Detects em/en-dashes in documentation and replaces them with hyphens.
+  Enabled: true
+  Severity: error
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.


### PR DESCRIPTION
Enable Documentation/TextSubstitution (em/en-dash -> hyphen) as an error to match the ecosystem standard, and replace existing em/en-dashes in documentation.