### PR TITLE
Read processing selectors from nested consumer_groups path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Testing Changelog
 
+## 2.6.2 (Unreleased)
+- [Fix] Read the processing `strategy_selector` and `expansions_selector` from their nested `config.internal.processing.consumer_groups.*` location. Karafka `2.6.0` moved these settings under the `consumer_groups` namespace; a temporary forwarding shim kept the old flat paths working and has been removed in Karafka, so read the nested paths directly. Requires Karafka `>= 2.6.0`.
+
 ## 2.6.1 (2026-08-05)
 - [Fix] Fix the dependency constraints.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-testing (2.6.1)
+    karafka-testing (2.6.2)
       karafka (>= 2.6.0.rc2, < 2.7.0)
       waterdrop (>= 2.10.0)
 

--- a/lib/karafka/testing/minitest/helpers.rb
+++ b/lib/karafka/testing/minitest/helpers.rb
@@ -261,14 +261,14 @@ module Karafka
           @consumer = topic.consumer.new
           @consumer.producer = Karafka::App.producer
           # Inject appropriate strategy so needed options and components are available
-          strategy = Karafka::App.config.internal.processing.strategy_selector.find(topic)
+          strategy = processing_cfg.consumer_groups.strategy_selector.find(topic)
           @consumer.singleton_class.include(strategy)
           @consumer.client = @_karafka_consumer_client
           @consumer.coordinator = coordinators.find_or_create(topic.name, 0)
           @consumer.coordinator.seek_offset = 0
           # Indicate usage as for tests no direct enqueuing happens
           @consumer.instance_variable_set(:@used, true)
-          expansions = processing_cfg.expansions_selector.find(topic)
+          expansions = processing_cfg.consumer_groups.expansions_selector.find(topic)
           expansions.each { |expansion| @consumer.singleton_class.include(expansion) }
           @_karafka_consumer_mappings[topic.id] = @consumer
           @consumer

--- a/lib/karafka/testing/rspec/helpers.rb
+++ b/lib/karafka/testing/rspec/helpers.rb
@@ -294,14 +294,14 @@ module Karafka
           consumer = topic.consumer.new
           consumer.producer = Karafka::App.producer
           # Inject appropriate strategy so needed options and components are available
-          strategy = processing_cfg.strategy_selector.find(topic)
+          strategy = processing_cfg.consumer_groups.strategy_selector.find(topic)
           consumer.singleton_class.include(strategy)
           consumer.client = _karafka_consumer_client
           consumer.coordinator = coordinators.find_or_create(topic.name, 0)
           consumer.coordinator.seek_offset = 0
           # Indicate usage as for tests no direct enqueuing happens
           consumer.instance_variable_set(:@used, true)
-          expansions = processing_cfg.expansions_selector.find(topic)
+          expansions = processing_cfg.consumer_groups.expansions_selector.find(topic)
           expansions.each { |expansion| consumer.singleton_class.include(expansion) }
 
           @_karafka_consumer_mappings[topic.id] = consumer

--- a/lib/karafka/testing/version.rb
+++ b/lib/karafka/testing/version.rb
@@ -3,6 +3,6 @@
 module Karafka
   module Testing
     # Current version of gem. It should match Karafka framework version
-    VERSION = "2.6.1"
+    VERSION = "2.6.2"
   end
 end


### PR DESCRIPTION
Karafka 2.6.0 moved the processing strategy_selector and expansions_selector settings under config.internal.processing.consumer_groups.*. A temporary forwarding shim in Karafka kept the old flat paths working, but it has been removed, so read the nested paths directly.

- lib/karafka/testing/rspec/helpers.rb
- lib/karafka/testing/minitest/helpers.rb

Requires Karafka >= 2.6.0 (already the gemspec floor). Bumps version to 2.6.2.